### PR TITLE
[Fix]クライアントメニューを登録に成功した際、フォームの中身を空にする

### DIFF
--- a/app/views/therapist/client_menus/_table.html.erb
+++ b/app/views/therapist/client_menus/_table.html.erb
@@ -20,7 +20,7 @@
             <td><%= client_menu.start_date.strftime("%Y年%m月%d日") %></td>
             <td>
               <%= link_to "編集", edit_therapist_client_client_menu_path(client, client_menu), class: "btn btn-success" %>
-              <%= link_to "削除", therapist_client_client_menu_path(client, client_menu), method: :delete, remote: true, class: "btn btn-danger" %>
+              <%= link_to "削除", therapist_client_client_menu_path(client, client_menu), method: :delete, data: {confirm: '本当に消しますか？'}, remote: true, class: "btn btn-danger" %>
             </td>
           </tr>
         <% end %>

--- a/app/views/therapist/client_menus/create.js.erb
+++ b/app/views/therapist/client_menus/create.js.erb
@@ -1,3 +1,5 @@
 $('#table').html('<%= j(render "table", client_menus: @client_menus, client: @client) %>');
 $('#notice').html("クライアントメニューの登録に成功しました");
 $('#errors').html("<%= j(render 'layouts/errors', obj: @client_menu) %>");
+$('#client_menu_menu_id').val("");
+$('#client_menu_start_date').val("");


### PR DESCRIPTION
* クライアントメニューを登録に成功した際、フォームの中身を空にした
* クライアントメニュー削除の際アラートを表示