### PR TITLE
[Fix]修正メモに記述したものを修正

### DIFF
--- a/app/controllers/public/sessions_controller.rb
+++ b/app/controllers/public/sessions_controller.rb
@@ -4,6 +4,10 @@ class Public::SessionsController < Devise::SessionsController
   # before_action :configure_sign_in_params, only: [:create]
   before_action :client_state, only: [:create]
 
+  def after_sign_out_path_for(resource)
+     new_client_session_path
+  end
+
   # GET /resource/sign_in
   # def new
   #   super

--- a/app/javascript/stylesheets/application.scss
+++ b/app/javascript/stylesheets/application.scss
@@ -17,3 +17,12 @@ thead tr{
 h3{
   text-shadow: 0 1px 1px rgb(0 0 0 / 30%);
 }
+
+@media screen and (max-width: 767px) {
+  .th_responsive{
+    padding-bottom: 0.25rem !important;
+  }
+  .td_responsive{
+    padding-top: 0.25rem !important;
+  }
+}

--- a/app/javascript/stylesheets/card_box.css
+++ b/app/javascript/stylesheets/card_box.css
@@ -9,3 +9,7 @@
 .card_box h3, .card_box h4{
   color: #606060;
 }
+
+.register{
+  background-color: #efffef;
+}

--- a/app/javascript/stylesheets/chat.css
+++ b/app/javascript/stylesheets/chat.css
@@ -42,3 +42,9 @@
 .message{
   width: 70%;
 }
+
+@media screen and (min-width: 1024px) {
+  #messages_all{
+    width: 80%;
+  }
+}

--- a/app/views/admin/_header.html.erb
+++ b/app/views/admin/_header.html.erb
@@ -23,9 +23,9 @@
                   <i class="fas fa-sign-out-alt mr-1"></i>ログアウト
                 <% end %>
               </li>
-            <% end %>
-          </ul>
-        </div>
+            </ul>
+          </div>
+        <% end %>
       </div>
     </div>
   </nav>

--- a/app/views/admin/clients/show.html.erb
+++ b/app/views/admin/clients/show.html.erb
@@ -29,28 +29,28 @@
       <div class="row justify-content-center">
         <table class="table table-borderless col-10 mt-3">
           <tr>
-            <th scope="row" class="d-block d-md-table-cell col-lg-4 col-xl-3">お名前</th>
-            <td class="d-block d-md-table-cell"><%= @client.client_name %></td>
+            <th scope="row" class="d-block d-md-table-cell col-lg-4 col-xl-3 th_responsive">お名前</th>
+            <td class="d-block d-md-table-cell td_responsive"><%= @client.client_name %></td>
           </tr>
           <tr>
-            <th scope="row" class="d-block d-md-table-cell col-lg-4 col-xl-3">フリガナ</th>
-            <td class="d-block d-md-table-cell"><%= @client.client_name_kana %></td>
+            <th scope="row" class="d-block d-md-table-cell col-lg-4 col-xl-3 th_responsive">フリガナ</th>
+            <td class="d-block d-md-table-cell td_responsive"><%= @client.client_name_kana %></td>
           </tr>
           <tr>
-            <th scope="row" class="d-block d-md-table-cell col-lg-4 col-xl-3">リハゴール</th>
-            <td class="d-block d-md-table-cell"><%= @client.purpose %></td>
+            <th scope="row" class="d-block d-md-table-cell col-lg-4 col-xl-3 th_responsive">リハゴール</th>
+            <td class="d-block d-md-table-cell td_responsive"><%= @client.purpose %></td>
           </tr>
           <tr>
-            <th scope="row" class="d-block d-md-table-cell col-lg-4 col-xl-3">メールアドレス</th>
-            <td class="d-block d-md-table-cell"><%= @client.email %></td>
+            <th scope="row" class="d-block d-md-table-cell col-lg-4 col-xl-3 th_responsive">メールアドレス</th>
+            <td class="d-block d-md-table-cell td_responsive"><%= @client.email %></td>
           </tr>
           <tr>
-            <th scope="row" class="d-block d-md-table-cell col-lg-4 col-xl-3">担当セラピスト</th>
-            <td class="d-block d-md-table-cell"><%= @client.therapist.therapist_name %></td>
+            <th scope="row" class="d-block d-md-table-cell col-lg-4 col-xl-3 th_responsive">担当セラピスト</th>
+            <td class="d-block d-md-table-cell td_responsive"><%= @client.therapist.therapist_name %></td>
           </tr>
           <tr>
-            <th scope="row" class="d-block d-md-table-cell col-lg-4 col-xl-3">ステータス</th>
-            <td class="d-block d-md-table-cell"><%= render "admin/clients/client_status", client: @client %></td>
+            <th scope="row" class="d-block d-md-table-cell col-lg-4 col-xl-3 th_responsive">ステータス</th>
+            <td class="d-block d-md-table-cell td_responsive"><%= render "admin/clients/client_status", client: @client %></td>
           </tr>
         </table>
       </div>
@@ -71,24 +71,24 @@
       <div class="row justify-content-center">
         <table class="table table-borderless col-10 mt-3">
           <tr>
-            <th scope="row" class="d-block d-md-table-cell col-lg-4 col-xl-3">お名前</th>
-            <td class="d-block d-md-table-cell"><%= @therapist.therapist_name %></td>
+            <th scope="row" class="d-block d-md-table-cell col-lg-4 col-xl-3 th_responsive">お名前</th>
+            <td class="d-block d-md-table-cell td_responsive"><%= @therapist.therapist_name %></td>
           </tr>
           <tr>
-            <th scope="row" class="d-block d-md-table-cell col-lg-4 col-xl-3">フリガナ</th>
-            <td class="d-block d-md-table-cell"><%= @therapist.therapist_name_kana %></td>
+            <th scope="row" class="d-block d-md-table-cell col-lg-4 col-xl-3 th_responsive">フリガナ</th>
+            <td class="d-block d-md-table-cell td_responsive"><%= @therapist.therapist_name_kana %></td>
           </tr>
           <tr>
-            <th scope="row" class="d-block d-md-table-cell col-lg-4 col-xl-3">メールアドレス</th>
-            <td class="d-block d-md-table-cell"><%= @therapist.email %></td>
+            <th scope="row" class="d-block d-md-table-cell col-lg-4 col-xl-3 th_responsive">メールアドレス</th>
+            <td class="d-block d-md-table-cell td_responsive"><%= @therapist.email %></td>
           </tr>
           <tr>
-            <th scope="row" class="d-block d-md-table-cell col-lg-4 col-xl-3">担当利用者</th>
-            <td class="d-block d-md-table-cell"><%= @therapist.clients.count %>人</td>
+            <th scope="row" class="d-block d-md-table-cell col-lg-4 col-xl-3 th_responsive">担当利用者</th>
+            <td class="d-block d-md-table-cell td_responsive"><%= @therapist.clients.count %>人</td>
           </tr>
           <tr>
-            <th scope="row" class="d-block d-md-table-cell col-lg-4 col-xl-3">ステータス</th>
-            <td class="d-block d-md-table-cell"><%= render "admin/therapists/therapist_status", therapist: @therapist %></td>
+            <th scope="row" class="d-block d-md-table-cell col-lg-4 col-xl-3 th_responsive">ステータス</th>
+            <td class="d-block d-md-table-cell td_responsive"><%= render "admin/therapists/therapist_status", therapist: @therapist %></td>
           </tr>
         </table>
       </div>

--- a/app/views/admin/invitations/edit.html.erb
+++ b/app/views/admin/invitations/edit.html.erb
@@ -1,22 +1,28 @@
-<h2><%= t "devise.invitations.edit.header" %></h2>
+<div class="row mt-5">
+  <div class="col-12 mb-3">
+    <h3><%= t "devise.invitations.edit.header" %></h3>
+  </div>
+</div>
 
-<%= form_for(resource, as: resource_name, url: invitation_path(resource_name), html: { method: :put }) do |f| %>
-  <%= render "therapist/shared/error_messages", resource: resource %>
-  <%= f.hidden_field :invitation_token, readonly: true %>
+<div class="card_box">
+  <%= form_with model: @therapist, url: therapist_invitation_path, method: :put do |f| %>
+    <%= render "layouts/errors", obj: @therapist %>
+    <%= f.hidden_field :invitation_token, readonly: true %>
 
-  <% if f.object.class.require_password_on_accepting %>
-    <div class="field">
-      <%= f.label :password %><br />
-      <%= f.password_field :password %>
-    </div>
+    <% if f.object.class.require_password_on_accepting %>
+      <div class="field row mb-3">
+        <%= f.label :password, class: "col-12 col-md-4 col-lg-3" %><br />
+        <%= f.password_field :password, class: "ml-3 ml-md-0 col-md-8 col-lg-3" %>
+      </div>
 
-    <div class="field">
-      <%= f.label :password_confirmation %><br />
-      <%= f.password_field :password_confirmation %>
+      <div class="field row mb-3">
+        <%= f.label :password_confirmation, value: "パスワード(確認用)", class: "col-12 col-md-4 col-lg-3" %><br />
+        <%= f.password_field :password_confirmation, class: "ml-3 ml-md-0 col-md-8 col-lg-3" %>
+      </div>
+    <% end %>
+
+    <div class="actions form-group d-flex justify-content-end">
+      <%= f.submit t("devise.invitations.edit.submit_button"), class: 'btn btn-success btn-md' %>
     </div>
   <% end %>
-
-  <div class="actions">
-    <%= f.submit t("devise.invitations.edit.submit_button") %>
-  </div>
-<% end %>
+</div>

--- a/app/views/admin/therapists/show.html.erb
+++ b/app/views/admin/therapists/show.html.erb
@@ -15,24 +15,24 @@
     <div class="row justify-content-center">
       <table class="table table-borderless col-10 mt-3">
         <tr>
-          <th scope="row" class="d-block d-md-table-cell col-lg-4 col-xl-3">お名前</th>
-          <td class="d-block d-md-table-cell"><%= @therapist.therapist_name %></td>
+          <th scope="row" class="d-block d-md-table-cell col-lg-4 col-xl-3 th_responsive">お名前</th>
+          <td class="d-block d-md-table-cell td_responsive"><%= @therapist.therapist_name %></td>
         </tr>
         <tr>
-          <th scope="row" class="d-block d-md-table-cell col-lg-4 col-xl-3">フリガナ</th>
-          <td class="d-block d-md-table-cell"><%= @therapist.therapist_name_kana %></td>
+          <th scope="row" class="d-block d-md-table-cell col-lg-4 col-xl-3 th_responsive">フリガナ</th>
+          <td class="d-block d-md-table-cell td_responsive"><%= @therapist.therapist_name_kana %></td>
         </tr>
         <tr>
-          <th scope="row" class="d-block d-md-table-cell col-lg-4 col-xl-3">メールアドレス</th>
-          <td class="d-block d-md-table-cell"><%= @therapist.email %></td>
+          <th scope="row" class="d-block d-md-table-cell col-lg-4 col-xl-3 th_responsive">メールアドレス</th>
+          <td class="d-block d-md-table-cell td_responsive"><%= @therapist.email %></td>
         </tr>
         <tr>
-          <th scope="row" class="d-block d-md-table-cell col-lg-4 col-xl-3">担当利用者</th>
-          <td class="d-block d-md-table-cell"><%= @therapist.clients.count %>人</td>
+          <th scope="row" class="d-block d-md-table-cell col-lg-4 col-xl-3 th_responsive">担当利用者</th>
+          <td class="d-block d-md-table-cell td_responsive"><%= @therapist.clients.count %>人</td>
         </tr>
         <tr>
-          <th scope="row" class="d-block d-md-table-cell col-lg-4 col-xl-3">ステータス</th>
-          <td class="d-block d-md-table-cell"><%= render "admin/therapists/therapist_status", therapist: @therapist %></td>
+          <th scope="row" class="d-block d-md-table-cell col-lg-4 col-xl-3 th_responsive">ステータス</th>
+          <td class="d-block d-md-table-cell td_responsive"><%= render "admin/therapists/therapist_status", therapist: @therapist %></td>
         </tr>
       </table>
     </div>

--- a/app/views/public/_header.html.erb
+++ b/app/views/public/_header.html.erb
@@ -1,5 +1,5 @@
 <header class="shadow-sm">
-  <nav class="navbar navbar-expand-lg navbar-light">
+  <nav class="navbar navbar-expand-xl navbar-light">
     <div class="container-fluid">
       <%= link_to "リハコネ", root_path, class: "navbar-brand text-light col-12 col-sm-3" %>
         <% if client_signed_in? %>
@@ -20,13 +20,18 @@
                 <% end %>
               </li>
               <li class="nav-item btn">
+                <%= link_to chat_path(current_client), class: 'nav-link active text-light text-right' do %>
+                  <i class="far fa-comment-dots mr-1"></i>チャット
+                <% end %>
+              </li>
+              <li class="nav-item btn">
                 <%= link_to destroy_client_session_path, method: :delete, class: 'nav-link active text-light text-right' do %>
                   <i class="fas fa-sign-out-alt mr-1"></i>ログアウト
                 <% end %>
               </li>
-            <% end %>
-          </ul>
-        </div>
+            </ul>
+          </div>
+        <% end %>
       </div>
     </div>
   </nav>

--- a/app/views/public/chats/show.html.erb
+++ b/app/views/public/chats/show.html.erb
@@ -4,7 +4,7 @@
   </div>
 </div>
 
-<div id="messages_all">
+<div id="messages_all" class="mx-auto">
   <% @chats.each do |chat| %>
     <% if chat.client_id == current_client.id %>
       <div class="d-flex justify-content-end">
@@ -37,6 +37,7 @@
     <% end %>
   <% end %>
 </div>
+
 <div id="errors">
   <%= render "layouts/errors", obj: @chat %>
 </div>

--- a/app/views/public/client_records/_form_edit.html.erb
+++ b/app/views/public/client_records/_form_edit.html.erb
@@ -1,0 +1,43 @@
+<div class="card_box">
+  <h4>体調</h4>
+  <%= form_with model: client_record, local: true do |f| %>
+    <div class="client_record form-group col-12">
+      <%= f.radio_button :condition, 1, checked: true %>
+      <%= f.label :condition, "良い" %>
+      <%= f.radio_button :condition, 2 %>
+      <%= f.label :condition, "普通" %>
+      <%= f.radio_button :condition, 3 %>
+      <%= f.label :condition, "悪い" %>
+    </div>
+
+    <h4>やったメニューチェック</h4>
+    <div class="client_record form-group col-12">
+      <% client_menus.each do |client_menu| %>
+        <%# hidden_fieldでまずはfalseをセットして絶対データを送る仕組みを作っている。%>
+        <%= hidden_field_tag "client_menus[#{client_menu.id}]", false %>
+        <div>
+          <%# 第一引数 : name, 第二引数 : 送信値, 第三引数 : 初期値(client_menu.is_completed), 第四引数 : オプション %>
+          <%= check_box_tag "client_menus[#{client_menu.id}]", true, client_menu.is_completed, {} %>
+          <label class="mr-3">
+            <%= client_menu.menu.menu_name %>
+          </label>
+        </div>
+      <% end %>
+    </div>
+
+    <h4>今日の一言</h4>
+    <div class="form-group col-12">
+      <%= f.text_area :comment, rows: "3", placeholder: "頑張れたことや、困ったことがありましたら、お書きください。", class: "form-control" %>
+    </div>
+    <div class="form-group">
+      <%= f.hidden_field :record_date, value: day %>
+    </div>
+    <div class="row justify-content-md-end">
+      <div class="col-5 ml-auto col-md-2 ml-md-0">
+        <div class="form-group">
+          <%= f.submit "更新", class: "btn btn_update btn-lg" %>
+        </div>
+      </div>
+    </div>
+  <% end %>
+</div>

--- a/app/views/public/client_records/_form_new.html.erb
+++ b/app/views/public/client_records/_form_new.html.erb
@@ -1,0 +1,43 @@
+<div class="card_box register">
+  <h4>体調</h4>
+  <%= form_with model: client_record, local: true do |f| %>
+    <div class="client_record form-group col-12">
+      <%= f.radio_button :condition, 1, checked: true %>
+      <%= f.label :condition, "良い" %>
+      <%= f.radio_button :condition, 2 %>
+      <%= f.label :condition, "普通" %>
+      <%= f.radio_button :condition, 3 %>
+      <%= f.label :condition, "悪い" %>
+    </div>
+
+    <h4>やったメニューチェック</h4>
+    <div class="client_record form-group col-12">
+      <% client_menus.each do |client_menu| %>
+        <%# hidden_fieldでまずはfalseをセットして絶対データを送る仕組みを作っている。%>
+        <%= hidden_field_tag "client_menus[#{client_menu.id}]", false %>
+        <div>
+          <%# 第一引数 : name, 第二引数 : 送信値, 第三引数 : 初期値(client_menu.is_completed), 第四引数 : オプション %>
+          <%= check_box_tag "client_menus[#{client_menu.id}]", true, client_menu.is_completed, {} %>
+          <label class="mr-3">
+            <%= client_menu.menu.menu_name %>
+          </label>
+        </div>
+      <% end %>
+    </div>
+
+    <h4>今日の一言</h4>
+    <div class="form-group col-12">
+      <%= f.text_area :comment, rows: "3", placeholder: "頑張れたことや、困ったことがありましたら、お書きください。", class: "form-control" %>
+    </div>
+    <div class="form-group">
+      <%= f.hidden_field :record_date, value: day %>
+    </div>
+    <div class="row justify-content-md-end">
+      <div class="col-5 ml-auto col-md-2 ml-md-0">
+        <div class="form-group">
+          <%= f.submit "記録", class: "btn btn-warning btn-lg" %>
+        </div>
+      </div>
+    </div>
+  <% end %>
+</div>

--- a/app/views/public/client_records/show.html.erb
+++ b/app/views/public/client_records/show.html.erb
@@ -3,51 +3,8 @@
     <h3><%= @day.strftime("%Y年%m月%d日") %>のリハビリ</h3>
   </div>
 </div>
-
-<div class="card_box">
-  <h4>体調</h4>
-  <%= form_with model: @client_record, local: true do |f| %>
-    <div class="client_record form-group col-12">
-      <%= f.radio_button :condition, 1, checked: true %>
-      <%= f.label :condition, "良い" %>
-      <%= f.radio_button :condition, 2 %>
-      <%= f.label :condition, "普通" %>
-      <%= f.radio_button :condition, 3 %>
-      <%= f.label :condition, "悪い" %>
-    </div>
-
-    <h4>やったメニューチェック</h4>
-    <div class="client_record form-group col-12">
-      <% @client_menus.each do |client_menu| %>
-        <%# hidden_fieldでまずはfalseをセットして絶対データを送る仕組みを作っている。%>
-        <%= hidden_field_tag "client_menus[#{client_menu.id}]", false %>
-        <div>
-          <%# 第一引数 : name, 第二引数 : 送信値, 第三引数 : 初期値(client_menu.is_completed), 第四引数 : オプション %>
-          <%= check_box_tag "client_menus[#{client_menu.id}]", true, client_menu.is_completed, {} %>
-          <label class="mr-3">
-            <%= client_menu.menu.menu_name %>
-          </label>
-        </div>
-      <% end %>
-    </div>
-
-    <h4>今日の一言</h4>
-    <div class="form-group col-12">
-      <%= f.text_area :comment, rows: "3", placeholder: "頑張れたことや、困ったことがありましたら、お書きください。", class: "form-control" %>
-    </div>
-    <div class="form-group">
-      <%= f.hidden_field :record_date, value: @day %>
-    </div>
-    <div class="row justify-content-md-end">
-      <div class="col-5 ml-auto col-md-2 ml-md-0">
-        <div class="form-group">
-          <% if @client_record.id.nil? %>
-            <%= f.submit "記録", class: "btn btn-warning btn-lg" %>
-          <% else %>
-            <%= f.submit "更新", class: "btn btn_update btn-lg" %>
-          <% end %>
-        </div>
-      </div>
-    </div>
-  <% end %>
-</div>
+<% if @client_record.id.nil? %>
+  <%= render "form_new", client_record: @client_record, client_menus: @client_menus, day: @day %>
+<% else %>
+  <%= render "form_edit", client_record: @client_record, client_menus: @client_menus, day: @day %>
+<% end %>

--- a/app/views/public/clients/show.html.erb
+++ b/app/views/public/clients/show.html.erb
@@ -28,24 +28,24 @@
       <div class="row justify-content-center">
         <table class="table table-borderless col-10 mt-3">
           <tr>
-            <th scope="row" class="d-block d-md-table-cell col-lg-4 col-xl-3">お名前</th>
-            <td class="d-block d-md-table-cell"><%= current_client.client_name %></td>
+            <th scope="row" class="d-block d-md-table-cell col-lg-4 col-xl-3 th_responsive">お名前</th>
+            <td class="d-block d-md-table-cell td_responsive"><%= current_client.client_name %></td>
           </tr>
           <tr>
-            <th scope="row" class="d-block d-md-table-cell col-lg-4 col-xl-3">フリガナ</th>
-            <td class="d-block d-md-table-cell"><%= current_client.client_name_kana %></td>
+            <th scope="row" class="d-block d-md-table-cell col-lg-4 col-xl-3 th_responsive">フリガナ</th>
+            <td class="d-block d-md-table-cell td_responsive"><%= current_client.client_name_kana %></td>
           </tr>
           <tr>
-            <th scope="row" class="d-block d-md-table-cell col-lg-4 col-xl-3">リハゴール</th>
-            <td class="d-block d-md-table-cell"><%= current_client.purpose %></td>
+            <th scope="row" class="d-block d-md-table-cell col-lg-4 col-xl-3 th_responsive">リハゴール</th>
+            <td class="d-block d-md-table-cell td_responsive"><%= current_client.purpose %></td>
           </tr>
           <tr>
-            <th scope="row" class="d-block d-md-table-cell col-lg-4 col-xl-3">メールアドレス</th>
-            <td class="d-block d-md-table-cell"><%= current_client.email %></td>
+            <th scope="row" class="d-block d-md-table-cell col-lg-4 col-xl-3 th_responsive">メールアドレス</th>
+            <td class="d-block d-md-table-cell td_responsive"><%= current_client.email %></td>
           </tr>
           <tr>
-            <th scope="row" class="d-block d-md-table-cell col-lg-4 col-xl-3">担当セラピスト</th>
-            <td class="d-block d-md-table-cell"><%= current_client.therapist.therapist_name %></td>
+            <th scope="row" class="d-block d-md-table-cell col-lg-4 col-xl-3 th_responsive">担当セラピスト</th>
+            <td class="d-block d-md-table-cell td_responsive"><%= current_client.therapist.therapist_name %></td>
           </tr>
         </table>
       </div>
@@ -66,22 +66,22 @@
       <div class="row justify-content-center">
         <table class="table table-borderless col-10 mt-3">
           <tr>
-            <th scope="row" class="d-block d-md-table-cell col-lg-4 col-xl-3">お名前</th>
-            <td class="d-block d-md-table-cell"><%= @therapist.therapist_name %></td>
+            <th scope="row" class="d-block d-md-table-cell col-lg-4 col-xl-3 th_responsive">お名前</th>
+            <td class="d-block d-md-table-cell td_responsive"><%= @therapist.therapist_name %></td>
           </tr>
           <tr>
-            <th scope="row" class="d-block d-md-table-cell col-lg-4 col-xl-3">フリガナ</th>
-            <td class="d-block d-md-table-cell"><%= @therapist.therapist_name_kana %></td>
+            <th scope="row" class="d-block d-md-table-cell col-lg-4 col-xl-3 th_responsive">フリガナ</th>
+            <td class="d-block d-md-table-cell td_responsive"><%= @therapist.therapist_name_kana %></td>
           </tr>
           <tr>
-            <th scope="row" class="d-block d-md-table-cell col-lg-4 col-xl-3">メールアドレス</th>
-            <td class="d-block d-md-table-cell"><%= @therapist.email %></td>
+            <th scope="row" class="d-block d-md-table-cell col-lg-4 col-xl-3 th_responsive">メールアドレス</th>
+            <td class="d-block d-md-table-cell td_responsive"><%= @therapist.email %></td>
           </tr>
         </table>
       </div>
       <div class="row justify-content-md-end">
         <div class="col-6 ml-auto col-md-4 ml-md-0">
-          <%= link_to "チャット", chat_path(current_client.id), class: "btn btn-lg btn_pink" %>
+          <%= link_to "チャット", chat_path(current_client), class: "btn btn-lg btn_pink" %>
         </div>
       </div>
     </div>

--- a/app/views/public/sessions/new.html.erb
+++ b/app/views/public/sessions/new.html.erb
@@ -1,6 +1,6 @@
 <div class="row">
   <div class="col-10 col-md-5 col-lg-4 mx-auto text-center mt-5">
-    <h2 class="mb-5"><strong>クライアント<br>ログイン</strong></h2>
+    <h2 class="mb-5"><strong>利用者ログイン</strong></h2>
 
     <%= form_with model: @client, url: client_session_path, local: true do |f| %>
       <div class="row field mb-3">

--- a/app/views/therapist/_header.html.erb
+++ b/app/views/therapist/_header.html.erb
@@ -19,8 +19,9 @@
                   <i class="fas fa-running mr-1"></i>自主トレメニュー
                 <% end %>
                 <div class="dropdown-menu" aria-labelledby="navbarDropdown">
-                  <%= link_to "自主トレメニュー", therapist_menus_path, class: "dropdown-item" %>
-                  <%= link_to "ジャンル", therapist_genres_path, class: "dropdown-item" %>
+                  <%= link_to "自主トレメニュー一覧", therapist_menus_path, class: "dropdown-item" %>
+                  <%= link_to "自主トレメニュー新規登録", new_therapist_menu_path, class: "dropdown-item" %>
+                  <%= link_to "ジャンル一覧", therapist_genres_path, class: "dropdown-item" %>
                 </div>
               </li>
               <li class="nav-item btn">
@@ -33,9 +34,9 @@
                   <i class="fas fa-sign-out-alt mr-1"></i>ログアウト
                 <% end %>
               </li>
-            <% end %>
-          </ul>
-        </div>
+            </ul>
+          </div>
+        <% end %>
       </div>
     </div>
   </nav>

--- a/app/views/therapist/chats/show.html.erb
+++ b/app/views/therapist/chats/show.html.erb
@@ -4,7 +4,7 @@
   </div>
 </div>
 
-<div id="messages_all">
+<div id="messages_all" class="mx-auto">
   <% @chats.each do |chat| %>
     <% if chat.therapist_id == current_therapist.id %>
       <div class="d-flex justify-content-end">
@@ -37,11 +37,12 @@
     <% end %>
   <% end %>
 </div>
+
 <div id="errors">
   <%= render "layouts/errors", obj: @chat %>
 </div>
 <%= form_with model: @chat, url: therapist_client_chats_path, local: false, class: "mb-3 d-flex justify-content-center" do |f| %>
-  <%= f.text_field :message, placeholder: "メッセージを入力してください", class: "message" %>
+  <%= f.text_area :message, rows: "1", placeholder: "メッセージを入力してください", class: "message form-control" %>
   <%= f.hidden_field :room_id, value: @room.id %>
   <%= f.submit "送信", class: "btn btn-info" %>
 <% end %>

--- a/app/views/therapist/client_menus/index.html.erb
+++ b/app/views/therapist/client_menus/index.html.erb
@@ -3,12 +3,12 @@
     <h3><%= @client.client_name %>さんのメニュー登録・一覧</h3>
   </div>
 </div>
-<h4>登録フォーム</h4>
-<div class="card_box">
-  <div id="errors">
-    <%= render "layouts/errors", obj: @client_menu %>
-  </div>
+<div class="card_box register">
+  <h3 class="mb-3">登録フォーム</h3>
   <%= form_with model: [@client, @client_menu], url: therapist_client_client_menus_path, local: false do |f| %>
+    <div id="errors">
+      <%= render "layouts/errors", obj: @client_menu %>
+    </div>
     <div class="form-group row">
       <%= f.label :menu_id, "メニュー名", class: "col-12 col-md-2" %>
       <%= f.select :menu_id, options_from_collection_for_select(Menu.all, :id, :menu_name), {include_blank: '選択してください'}, {class: "col-12 col-md-8"} %>

--- a/app/views/therapist/clients/show.html.erb
+++ b/app/views/therapist/clients/show.html.erb
@@ -12,7 +12,7 @@
         <%= image_tag @client.get_client_image(100, 100), class: "rounded-circle" %>
       </div>
       <div class="col-lg-8 mt-auto d-flex justify-content-between">
-        <%= link_to "メニュー設定", therapist_client_client_menus_path(@client), class: "mb-2 d-block btn btn-info btn-md" %>
+        <%= link_to "メニュー設定", therapist_client_client_menus_path(@client), class: "mb-2 d-block btn btn-primary btn-md" %>
         <%= link_to "記録確認", therapist_client_client_records_path(@client), class: "mb-2 d-block btn btn-warning btn-md" %>
         <%= link_to "チャット", therapist_client_chat_path(@client), class: "mb-2 d-block btn btn_pink btn-md" %>
       </div>
@@ -21,24 +21,24 @@
   <div class="row justify-content-center">
     <table class="table table-borderless col-10 mt-3">
       <tr>
-        <th scope="row" class="d-block d-md-table-cell col-lg-4 col-xl-3">お名前</th>
-        <td class="d-block d-md-table-cell"><%= @client.client_name %></td>
+        <th scope="row" class="d-block d-md-table-cell col-lg-4 col-xl-3 th_responsive">お名前</th>
+        <td class="d-block d-md-table-cell td_responsive"><%= @client.client_name %></td>
       </tr>
       <tr>
-        <th scope="row" class="d-block d-md-table-cell col-lg-4 col-xl-3">フリガナ</th>
-        <td class="d-block d-md-table-cell"><%= @client.client_name_kana %></td>
+        <th scope="row" class="d-block d-md-table-cell col-lg-4 col-xl-3 th_responsive">フリガナ</th>
+        <td class="d-block d-md-table-cell td_responsive"><%= @client.client_name_kana %></td>
       </tr>
       <tr>
-        <th scope="row" class="d-block d-md-table-cell col-lg-4 col-xl-3">リハゴール</th>
-        <td class="d-block d-md-table-cell"><%= @client.purpose %></td>
+        <th scope="row" class="d-block d-md-table-cell col-lg-4 col-xl-3 th_responsive">リハゴール</th>
+        <td class="d-block d-md-table-cell td_responsive"><%= @client.purpose %></td>
       </tr>
       <tr>
-        <th scope="row" class="d-block d-md-table-cell col-lg-4 col-xl-3">メールアドレス</th>
-        <td class="d-block d-md-table-cell"><%= @client.email %></td>
+        <th scope="row" class="d-block d-md-table-cell col-lg-4 col-xl-3 th_responsive">メールアドレス</th>
+        <td class="d-block d-md-table-cell td_responsive"><%= @client.email %></td>
       </tr>
       <tr>
-        <th scope="row" class="d-block d-md-table-cell col-lg-4 col-xl-3">ステータス</th>
-        <td class="d-block d-md-table-cell"><%= render "admin/clients/client_status", client: @client %></td>
+        <th scope="row" class="d-block d-md-table-cell col-lg-4 col-xl-3 th_responsive">ステータス</th>
+        <td class="d-block d-md-table-cell td_responsive"><%= render "admin/clients/client_status", client: @client %></td>
       </tr>
     </table>
   </div>

--- a/app/views/therapist/genres/_edit.html.erb
+++ b/app/views/therapist/genres/_edit.html.erb
@@ -1,15 +1,17 @@
-<div class="col-md-8 mb-3">
-  <h3>ジャンル編集</h3>
-</div>
-<div class="row justify-content-center">
-  <div class="col-10">
-    <div id="errors">
-      <%= render "layouts/errors", obj: @genre %>
+<div class="card_box">
+  <div class="col-md-8 mb-3">
+    <h3>ジャンル編集</h3>
+  </div>
+  <div class="row justify-content-center">
+    <div class="col-10">
+      <div id="errors">
+        <%= render "layouts/errors", obj: @genre %>
+      </div>
+      <%= form_with model: @genre, url: therapist_genre_path, local: false, class: "row mb-3" do |f| %>
+        <%= f.label :genre_name, "ジャンル名", class: "col-md-3 col-lg-2 mb-1 mb-md-0 d-flex align-items-center" %>
+        <%= f.text_field :genre_name, placeholder: "ジャンル名", class: "col-md-4 mb-3 mb-md-0 ml-md-5 mr-md-5" %>
+        <%= f.submit "更新", class: "btn btn_update btn-lg ml-auto ml-md-0" %>
+      <% end %>
     </div>
-    <%= form_with model: @genre, url: therapist_genre_path, local: false, class: "row mb-3" do |f| %>
-      <%= f.label :genre_name, "ジャンル名", class: "col-md-3 col-lg-2 mb-1 mb-md-0 d-flex align-items-center" %>
-      <%= f.text_field :genre_name, placeholder: "ジャンル名", class: "col-md-4 mb-3 mb-md-0 ml-md-5 mr-md-5" %>
-      <%= f.submit "更新", class: "btn btn_update btn-lg ml-auto ml-md-0" %>
-    <% end %>
   </div>
 </div>

--- a/app/views/therapist/genres/_new.html.erb
+++ b/app/views/therapist/genres/_new.html.erb
@@ -1,15 +1,17 @@
-<div class="col-md-8 mb-3">
-  <h3>ジャンル登録</h3>
-</div>
-<div class="row justify-content-center">
-  <div class="col-10">
-    <div id="errors">
-      <%= render "layouts/errors", obj: genre %>
+<div class="card_box register">
+  <div class="col-md-8 mb-3">
+    <h3>ジャンル登録</h3>
+  </div>
+  <div class="row justify-content-center">
+    <div class="col-10">
+      <%= form_with model: genre, url: therapist_genres_path, local: false, class: "row mb-3" do |f| %>
+        <div id="errors">
+          <%= render "layouts/errors", obj: genre %>
+        </div>
+        <%= f.label :genre_name, "ジャンル名", class: "col-md-3 col-lg-2 mb-1 mb-md-0 d-flex align-items-center" %>
+        <%= f.text_field :genre_name, placeholder: "ジャンル名", class: "col-md-4 mb-3 mb-md-0 ml-md-5 mr-md-5" %>
+        <%= f.submit "登録", class: "btn btn-info btn-lg ml-auto ml-md-0" %>
+      <% end %>
     </div>
-    <%= form_with model: genre, url: therapist_genres_path, local: false, class: "row mb-3" do |f| %>
-      <%= f.label :genre_name, "ジャンル名", class: "col-md-3 col-lg-2 mb-1 mb-md-0 d-flex align-items-center" %>
-      <%= f.text_field :genre_name, placeholder: "ジャンル名", class: "col-md-4 mb-3 mb-md-0 ml-md-5 mr-md-5" %>
-      <%= f.submit "登録", class: "btn btn-info btn-lg ml-auto ml-md-0" %>
-    <% end %>
   </div>
 </div>

--- a/app/views/therapist/genres/index.html.erb
+++ b/app/views/therapist/genres/index.html.erb
@@ -4,7 +4,7 @@
   </div>
 </div>
 
-<div class="card_box" id="genre">
+<div id="genre">
   <%= render "new", genre: @genre %>
 </div>
 

--- a/app/views/therapist/invitations/edit.html.erb
+++ b/app/views/therapist/invitations/edit.html.erb
@@ -1,22 +1,28 @@
-<h2><%= t "devise.invitations.edit.header" %></h2>
+<div class="row mt-5">
+  <div class="col-12 mb-3">
+    <h3><%= t "devise.invitations.edit.header" %></h3>
+  </div>
+</div>
 
-<%= form_for(resource, as: resource_name, url: invitation_path(resource_name), html: { method: :put }) do |f| %>
-  <%= render "public/shared/error_messages", resource: resource %>
-  <%= f.hidden_field :invitation_token, readonly: true %>
+<div class="card_box">
+  <%= form_with model: @client, url: client_invitation_path, method: :put do |f| %>
+    <%= render "layouts/errors", obj: @client %>
+    <%= f.hidden_field :invitation_token, readonly: true %>
 
-  <% if f.object.class.require_password_on_accepting %>
-    <div class="field">
-      <%= f.label :password %><br />
-      <%= f.password_field :password %>
-    </div>
+    <% if f.object.class.require_password_on_accepting %>
+      <div class="field row mb-3">
+        <%= f.label :password, class: "col-12 col-md-4 col-lg-3" %><br />
+        <%= f.password_field :password, class: "ml-3 ml-md-0 col-md-8 col-lg-3" %>
+      </div>
 
-    <div class="field">
-      <%= f.label :password_confirmation %><br />
-      <%= f.password_field :password_confirmation %>
+      <div class="field row mb-3">
+        <%= f.label :password_confirmation, value: "パスワード(確認用)", class: "col-12 col-md-4 col-lg-3" %><br />
+        <%= f.password_field :password_confirmation, class: "ml-3 ml-md-0 col-md-8 col-lg-3" %>
+      </div>
+    <% end %>
+
+    <div class="actions form-group d-flex justify-content-end">
+      <%= f.submit t("devise.invitations.edit.submit_button"), class: 'btn btn-success btn-md' %>
     </div>
   <% end %>
-
-  <div class="actions">
-    <%= f.submit t("devise.invitations.edit.submit_button") %>
-  </div>
-<% end %>
+</div>

--- a/app/views/therapist/menus/edit.html.erb
+++ b/app/views/therapist/menus/edit.html.erb
@@ -1,15 +1,11 @@
 <div class="row mt-5">
   <div class="col-12 mb-3">
-    <h3>メニュー編集</h3>
+    <h3>自主トレメニュー編集</h3>
   </div>
 </div>
 <div class="card_box">
   <%= form_with model: @menu, url: therapist_menu_path, local: true do |f| %>
     <%= render "layouts/errors", obj: @menu %>
-    <div class="field row mb-3">
-      <%= f.label :menu_video, "メニュー動画", class: "col-12 col-md-3 col-lg-2" %>
-      <%= f.file_field :menu_video, accept: "video/*", class: "col-12 col-md-8 pl-0" %>
-    </div>
     <div class="field row mb-3">
       <%= f.label :menu_name, "メニュー名", class: "col-12 col-md-3 col-lg-2" %>
       <%= f.text_field :menu_name, placeholder: "メニュー名", class: "col-12 col-md-8" %>
@@ -25,6 +21,10 @@
     <div class="field row mb-3">
       <%= f.label :genre_id, "ジャンル", class: "col-12 col-md-3 col-lg-2" %>
       <%= f.select :genre_id, options_from_collection_for_select(Genre.all, :id, :genre_name), {include_blank: '選択してください'}, {class: "col-12 col-md-8"} %>
+    </div>
+    <div class="field row mb-3">
+      <%= f.label :menu_video, "メニュー動画", class: "col-12 col-md-3 col-lg-2" %>
+      <%= f.file_field :menu_video, accept: "video/*", class: "col-12 col-md-8 pl-0" %>
     </div>
     <div class="form-group d-flex justify-content-end">
       <%= f.submit "更新", class: "btn btn_update btn-lg" %>

--- a/app/views/therapist/menus/new.html.erb
+++ b/app/views/therapist/menus/new.html.erb
@@ -1,16 +1,12 @@
 <div class="row mt-5">
   <div class="col-12 mb-3">
-    <h3>メニュー新規登録</h3>
+    <h3>自主トレメニュー新規登録</h3>
   </div>
 </div>
 
-<div class="card_box">
+<div class="card_box register">
   <%= form_with model: @menu, url: therapist_menus_path, local: true do |f| %>
     <%= render "layouts/errors", obj: @menu %>
-    <div class="field row mb-3">
-      <%= f.label :menu_video, "メニュー動画", class: "col-12 col-md-3 col-lg-2" %>
-      <%= f.file_field :menu_video, accept: "video/*", class: "col-12 col-md-8 pl-0" %>
-    </div>
     <div class="field row mb-3">
       <%= f.label :menu_name, "メニュー名", class: "col-12 col-md-3 col-lg-2" %>
       <%= f.text_field :menu_name, placeholder: "メニュー名", class: "col-12 col-md-8" %>
@@ -26,6 +22,10 @@
     <div class="field row mb-3">
       <%= f.label :genre_id, "ジャンル", class: "col-12 col-md-3 col-lg-2" %>
       <%= f.select :genre_id, options_from_collection_for_select(Genre.all, :id, :genre_name), {include_blank: '選択してください'}, {class: "col-12 col-md-8"} %>
+    </div>
+    <div class="field row mb-3">
+      <%= f.label :menu_video, "メニュー動画", class: "col-12 col-md-3 col-lg-2" %>
+      <%= f.file_field :menu_video, accept: "video/*", class: "col-12 col-md-8 pl-0" %>
     </div>
     <div class="form-group d-flex justify-content-end">
       <%= f.submit "登録", class: "btn btn-info btn-lg" %>

--- a/app/views/therapist/menus/show.html.erb
+++ b/app/views/therapist/menus/show.html.erb
@@ -1,6 +1,6 @@
 <div class="row mt-5">
   <div class="col-12 mb-3">
-    <h3>メニュー詳細</h3>
+    <h3>自主トレメニュー詳細</h3>
   </div>
 </div>
 <div class="row">

--- a/app/views/therapist/therapists/show.html.erb
+++ b/app/views/therapist/therapists/show.html.erb
@@ -16,20 +16,20 @@
     <div class="row justify-content-center">
       <table class="table table-borderless col-10 mt-3">
         <tr>
-          <th scope="row" class="d-block d-md-table-cell col-lg-4 col-xl-3">お名前</th>
-          <td class="d-block d-md-table-cell"><%= current_therapist.therapist_name %></td>
+          <th scope="row" class="d-block d-md-table-cell col-lg-4 col-xl-3 th_responsive">お名前</th>
+          <td class="d-block d-md-table-cell td_responsive"><%= current_therapist.therapist_name %></td>
         </tr>
         <tr>
-          <th scope="row" class="d-block d-md-table-cell col-lg-4 col-xl-3">フリガナ</th>
-          <td class="d-block d-md-table-cell"><%= current_therapist.therapist_name_kana %></td>
+          <th scope="row" class="d-block d-md-table-cell col-lg-4 col-xl-3 th_responsive">フリガナ</th>
+          <td class="d-block d-md-table-cell td_responsive"><%= current_therapist.therapist_name_kana %></td>
         </tr>
         <tr>
-          <th scope="row" class="d-block d-md-table-cell col-lg-4 col-xl-3">メールアドレス</th>
-          <td class="d-block d-md-table-cell"><%= current_therapist.email %></td>
+          <th scope="row" class="d-block d-md-table-cell col-lg-4 col-xl-3 th_responsive">メールアドレス</th>
+          <td class="d-block d-md-table-cell td_responsive"><%= current_therapist.email %></td>
         </tr>
         <tr>
-          <th scope="row" class="d-block d-md-table-cell col-lg-4 col-xl-3">担当利用者</th>
-          <td class="d-block d-md-table-cell"><%= current_therapist.clients.count %>人</td>
+          <th scope="row" class="d-block d-md-table-cell col-lg-4 col-xl-3 th_responsive">担当利用者</th>
+          <td class="d-block d-md-table-cell td_responsive"><%= current_therapist.clients.count %>人</td>
         </tr>
       </table>
     </div>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -5,18 +5,19 @@ ja:
   devise:
     sessions:
       client:
-        signed_in: "ログインに成功しました。"
-        signed_out: "ログアウトしました。"
+        signed_in: "ログインに成功しました"
+        signed_out: "ログアウトしました"
       therapist:
-        signed_in: "ログインに成功しました。"
-        signed_out: "ログアウトしました。"
+        signed_in: "ログインに成功しました"
+        signed_out: "ログアウトしました"
       admin:
-        signed_in: "ログインに成功しました。"
-        signed_out: "ログアウトしました。"
+        signed_in: "ログインに成功しました"
+        signed_out: "ログアウトしました"
     registrations:
-      customer:
-        signed_up: "サインアップに成功しました。"
-      therapist: "サインアップに成功しました。"
+      client:
+        signed_up: "サインアップに成功しました"
+      therapist:
+        signed_up: "サインアップに成功しました"
   activerecord:
     attributes:
       client:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,18 +1,16 @@
 Rails.application.routes.draw do
 
-  devise_for :clients, controllers: {
-    registrations: 'public/registrations',
+  devise_for :clients, skip: [:registrations, :passwords], controllers: {
     sessions: 'public/sessions',
     invitations: 'therapist/invitations'
   }
 
-  devise_for :therapist, skip: [:passwords], controllers: {
-    registrations: 'therapist/registrations',
+  devise_for :therapist, skip: [:registrations, :passwords], controllers: {
     sessions: 'therapist/sessions',
     invitations: 'admin/invitations'
   }
 
-  devise_for :admin, skip: [:registrations, :passwords], controllers: {
+  devise_for :admin, skip: [:registrations, :passwords, :invitations], controllers: {
     sessions: 'admin/sessions',
   }
 


### PR DESCRIPTION
* 利用者がログアウト後の遷移先を変更
* 画面が狭い場合、テーブルのth, tdのパディングを変更
* 登録フォームに背景色をつけた
* 画面が広い場合、メッセージの表示幅を変更
* ヘッダーのタグの順番を修正
* 招待後のパスワード登録画面のレイアウトを整えた
* 利用者のヘッダーにチャットを追加し、ハンバーガーメニューに切り替わるブレイクポイントを変更
* セラピストのドロップダウンメニューの中身を変更
* チャット送信フォームをテキストフィールドからテキストエリアに変更
* メニュー設定ボタンの色を変更
* メニューから自主トレメニューに名前を変更
* 不要なルーティングを削除